### PR TITLE
Обновлен гайд про команду запуска

### DIFF
--- a/pages/guides/startup-command.md
+++ b/pages/guides/startup-command.md
@@ -1,8 +1,48 @@
 ---
 title: Изменить команду запуска
-description: Инструкция по изменении команды запуска на superhub.host.
+description: Инструкция по изменении команды запуска на вашем сервере.
 ---
 
-Для изменения команды запуска сервера в контейнере необходимо сделать запрос в тех.поддержку, передав нужные флаги. 
+В данном гайде представлен обзор стандартных аргументов JVM (Java Virtual Machine) для сервера Minecraft для различных ядер.
 
-После выполнения задачи сервер следует перезапустить.
+## Minecraft Java Edition
+### Ядро Vanilla
+Официальный сервер для Java Edition, не поддерживающий плагины/моды.
+
+Стандартные аргументы JVM: `-Xms128M -XX:MaxRAMPercentage=95.0`
+
+### Ядро Paper
+Оптимизированный сервер с поддержкой плагинов для Bukkit и Spigot.
+
+Стандартные аргументы JVM: `-Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true`
+
+### Ядро Purpur
+Форк Paper, добавляющий новые игровые механики, поддерживающий плагины для Bukkit/Spigot/Paper.
+
+Стандартные аргументы JVM: `-Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true`
+
+### Ядро Forge
+Сервер с поддержкой Forge модов.
+
+Стандартные аргументы JVM: `-Xms128M -XX:MaxRAMPercentage=95.0`
+
+### Ядро Fabric
+Сервер с поддержкой Fabric модов.
+
+Стандартные аргументы JVM: `-Xms128M -XX:MaxRAMPercentage=95.0`
+
+## Minecraft Proxy
+### Ядро Velocity
+Современный прокси-сервер для Minecraft Java Edition, не поддерживающий плагины для BungeeCord.
+
+Стандартные аргументы JVM: `-Xms128M -XX:MaxRAMPercentage=95.0 -XX:+UseG1GC -XX:G1HeapRegionSize=4M -XX:+UnlockExperimentalVMOptions -XX:+ParallelRefProcEnabled -XX:+AlwaysPreTouch -XX:MaxInlineLevel=15`
+
+### Ядро Waterfall
+Форк BungeeCord с улучшенной стабильностью и производительностью.
+
+Стандартные аргументы JVM: `-Xms128M -XX:MaxRAMPercentage=95.0 -Dterminal.jline=false -Dterminal.ansi=true`
+
+### Ядро BungeeCord
+Классический прокси-сервер для Minecraft Java Edition.
+
+Стандартные аргументы JVM: `-Xms128M -XX:MaxRAMPercentage=95.0`


### PR DESCRIPTION
В связи с последним обновлением на хостинге возникла ситуация, в результате которой был создано одно обращение. В данном обращении клиент сообщио об удалении стандартных аргументов JVM и не смог их восстановить.

Также нужна картинка на 6 строчку1!!!!1!1!1!!!!!
https://i.imgur.com/ffUYj02.png